### PR TITLE
wip: discontinue exposed interfaces, use generics

### DIFF
--- a/example/custom-ranger-asn.go
+++ b/example/custom-ranger-asn.go
@@ -37,7 +37,7 @@ func (b *customRangerEntry) Asn() string {
 }
 
 // create customRangerEntry object using net and asn
-func newCustomRangerEntry(ipNet netip.Prefix, asn string) cidranger.RangerEntry {
+func newCustomRangerEntry(ipNet netip.Prefix, asn string) cidranger.Entry {
 	return &customRangerEntry{
 		ipNet: ipNet,
 		asn:   asn,
@@ -48,7 +48,7 @@ func newCustomRangerEntry(ipNet netip.Prefix, asn string) cidranger.RangerEntry 
 func main() {
 
 	// instantiate NewPCTrieRanger
-	ranger := cidranger.NewPCTrieRanger()
+	ranger := cidranger.New()
 
 	// Load sample data using our custom function
 	network := netip.MustParsePrefix("192.168.1.0/24")

--- a/version.go
+++ b/version.go
@@ -6,38 +6,38 @@ import (
 	rnet "github.com/yl2chen/cidranger/net"
 )
 
-type rangerFactory func(rnet.IPVersion) Ranger
+type rangerFactory[T any] func(rnet.IPVersion) iface[T]
 
-type versionedRanger struct {
-	ipV4Ranger Ranger
-	ipV6Ranger Ranger
+type versionedRanger[T any] struct {
+	ipV4Ranger iface[T]
+	ipV6Ranger iface[T]
 }
 
-func newVersionedRanger(factory rangerFactory) Ranger {
-	return &versionedRanger{
+func newVersionedRanger[T any](factory rangerFactory[T]) iface[T] {
+	return &versionedRanger[T]{
 		ipV4Ranger: factory(rnet.IPv4),
 		ipV6Ranger: factory(rnet.IPv6),
 	}
 }
 
-func (v *versionedRanger) Insert(entry RangerEntry) error {
-	network := entry.Network()
-	ranger, err := v.getRangerForIP(network.Addr())
+func (v *versionedRanger[T]) Insert(prefix netip.Prefix, value T) error {
+	ranger, err := v.getRangerForIP(prefix.Addr())
 	if err != nil {
 		return err
 	}
-	return ranger.Insert(entry)
+	return ranger.Insert(prefix, value)
 }
 
-func (v *versionedRanger) Remove(network netip.Prefix) (RangerEntry, error) {
-	ranger, err := v.getRangerForIP(network.Addr())
+func (v *versionedRanger[T]) Remove(prefix netip.Prefix) (T, bool, error) {
+	ranger, err := v.getRangerForIP(prefix.Addr())
 	if err != nil {
-		return nil, err
+		var zero T
+		return zero, false, err
 	}
-	return ranger.Remove(network)
+	return ranger.Remove(prefix)
 }
 
-func (v *versionedRanger) Contains(ip netip.Addr) (bool, error) {
+func (v *versionedRanger[T]) Contains(ip netip.Addr) (bool, error) {
 	ranger, err := v.getRangerForIP(ip)
 	if err != nil {
 		return false, err
@@ -45,7 +45,7 @@ func (v *versionedRanger) Contains(ip netip.Addr) (bool, error) {
 	return ranger.Contains(ip)
 }
 
-func (v *versionedRanger) ContainingNetworks(ip netip.Addr) ([]RangerEntry, error) {
+func (v *versionedRanger[T]) ContainingNetworks(ip netip.Addr) ([]T, error) {
 	ranger, err := v.getRangerForIP(ip)
 	if err != nil {
 		return nil, err
@@ -53,20 +53,20 @@ func (v *versionedRanger) ContainingNetworks(ip netip.Addr) ([]RangerEntry, erro
 	return ranger.ContainingNetworks(ip)
 }
 
-func (v *versionedRanger) CoveredNetworks(network netip.Prefix) ([]RangerEntry, error) {
-	ranger, err := v.getRangerForIP(network.Addr())
+func (v *versionedRanger[T]) CoveredNetworks(prefix netip.Prefix) ([]T, error) {
+	ranger, err := v.getRangerForIP(prefix.Addr())
 	if err != nil {
 		return nil, err
 	}
-	return ranger.CoveredNetworks(network)
+	return ranger.CoveredNetworks(prefix)
 }
 
 // Len returns number of networks in ranger.
-func (v *versionedRanger) Len() int {
+func (v *versionedRanger[T]) Len() int {
 	return v.ipV4Ranger.Len() + v.ipV6Ranger.Len()
 }
 
-func (v *versionedRanger) getRangerForIP(ip netip.Addr) (Ranger, error) {
+func (v *versionedRanger[T]) getRangerForIP(ip netip.Addr) (iface[T], error) {
 	if ip.Is4() {
 		return v.ipV4Ranger, nil
 	} else if ip.Is6() {


### PR DESCRIPTION
Builds on @monoidic's netip work

This branch is presently broken
(tests won't pass and may not be usable),
but is intended to demonstrate an alternative API using generics: since @monoidic's netip changes would be backwards incompatible, and since there is a better way, with generics,
to express this kind of data-structure,
that also has better allocation efficiency,
we should consider such changes alongside the netip proposal (in order to get more value out of compatibility breakage).

The v1 release could be implemented in terms of the proposed v2 changes via a minimal wrapper implementation:
adapting between v1 and v2 signatures, and API styles, while otherwise retaining original semantics.

Notable changes:

- Exposed/returned interfaces are removed in favor of generics for associated-value bundling. See https://github.com/golang/go/wiki/CodeReviewComments#interfaces
- prefixTrie is renamed to Trie and exposed directly.
- Ranger is hidden (it's just used for testing against bruteRanger); external callers most likely will not be juggling multiple implementations of this interfaces, and even if they did, they could create their own interface per established best practice.
- The stored value is T instead of *T to minimize GC objects (though the user can still create a `Trie[*MyStruct]` for example).
- Instead of methods expressed in terms of RangerEntry, keys and values are separately handled.
  - As a consequence, methods which returned RangerEntry now return a (T, bool) pair to allow distinguishing zero values.
  - It's not clear if fetching the prefix of a returned RangerEntry via the Network() method was a real _caller_ use-case; if it is (or if the output network differs from the input prefix), then Entry would continue to have a use-case, and the methods can be adjusted to use a generic concrete Entry data struct type instead (containing netip.Prefix and T).
- Many uses of the term "network" are changed to "prefix" to match netip's terminology.